### PR TITLE
Use official typos pre-commit and add to the default mapping

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,7 +100,7 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
-  - repo: https://github.com/adhtruong/mirrors-typos
+  - repo: https://github.com/crate-ci/typos
     rev: v1.36.2
     hooks:
       - id: typos

--- a/src/sync_with_uv/repo_data.py
+++ b/src/sync_with_uv/repo_data.py
@@ -10,6 +10,7 @@ REPO_TO_PACKAGE = {
     "https://github.com/adamchainz/djade-pre-commit": "djade",
     "https://github.com/astral-sh/ruff-pre-commit": "ruff",
     "https://github.com/charliermarsh/ruff-pre-commit": "ruff",
+    "https://github.com/crate-ci/typos": "typos",
     "https://github.com/pre-commit/mirrors-autopep8": "autopep8",
     "https://github.com/pre-commit/mirrors-clang-format": "clang-format",
     "https://github.com/pre-commit/mirrors-isort": "isort",


### PR DESCRIPTION
## Summary by Sourcery

Replace the adhtruong typos mirror with the official crate-ci/typos hook and include it in the default repository mapping

Enhancements:
- Switch the Typos pre-commit hook to the official crate-ci/typos repository
- Add crate-ci/typos URL to the repo-to-tool mapping in sync_with_uv/repo_data.py