### PR TITLE
Sync pragma-annotated additional_dependencies with uv.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### New Features
 
+- **Sync `additional_dependencies`**:
+  Pin dependencies in `additional_dependencies` (or any dependency line)
+  to the `uv.lock` version. Opt-in per line via a `# sync-with-uv` pragma comment;
+  any specifier (`==`, `>=`, `~=`, ...) is rewritten to an exact `==` pin, and a
+  pin is added to a bare dependency that has none.
+  Since the pragma is an explicit request, the tool errors if an annotated line's
+  package is missing from `uv.lock`, or the line has no dependency to sync.
 - **`prek.toml` support**:
   Sync hook versions in `prek.toml` configs, in addition to `.pre-commit-config.yaml` (#35)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ This tool synchronizes pre-commit hook versions with those in uv.lock to ensure 
 src/sync_with_uv/
 ├── cli.py              # Cyclopts-based CLI interface with diff/check/write modes
 ├── sync_with_uv.py     # Core logic for parsing uv.lock and updating configs
+├── dependency_line.py  # Parsing/pinning of `# sync-with-uv` dependency lines
 ├── repo_data.py        # Mapping tables for GitHub repo URLs to package names
 ├── __init__.py         # Package initialization
 ├── __main__.py         # Module entry point (python -m sync_with_uv)
@@ -63,6 +64,7 @@ src/sync_with_uv/
 ### Key Functions
 
 - `load_uv_lock()`: Parses uv.lock TOML and extracts package versions
-- `process_precommit_text()`: Regex-based parsing and updating of .pre-commit-config.yaml
+- `process_config_text()`: Regex-based parsing and updating of .pre-commit-config.yaml / prek.toml
+- `sync_dependency_line()`: Pins a `# sync-with-uv`-annotated dependency line to its uv.lock version
 - `repo_to_package()`: Maps GitHub URLs to Python package names
 - `repo_to_version_template()`: Handles version prefix patterns (v-prefixed vs plain versions)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,55 @@ sync-with-uv -p custom-precommit.yaml -u custom-lock.toml
 
 Note: If you use the tools with a custom file location, remember to also change the `files` setting in `.pre-commit-config.toml`.
 
+## Syncing additional dependencies
+
+Besides the `rev` of each hook, the tool can also sync version pins inside
+`additional_dependencies` (or any other dependency line).
+Because these lists can contain arbitrary packages,
+syncing is strictly opt-in per line:
+a dependency is only touched if its line carries a `# sync-with-uv` pragma comment.
+
+```yaml
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.5.1
+  hooks:
+    - id: mypy
+      additional_dependencies:
+        - pydantic==2.0.0  # sync-with-uv
+        - types-requests>=2.0  # sync-with-uv
+        - httpx  # sync-with-uv
+        - some-other-lib==1.0.0  # left alone, no pragma
+```
+
+For every annotated line, the dependency is pinned to an exact version
+(`==`) from `uv.lock`, adding a specifier when the dependency has none,
+so the example above becomes `pydantic==<locked>`, `types-requests==<locked>`,
+and `httpx==<locked>`.
+The package name, extras (like `pydantic[email]`), environment markers
+(like `; python_version < "3.11"`), quoting, and the comment itself are preserved.
+
+Because the pragma is an explicit request to sync a line,
+the tool errors (exit code 123) when an annotated line cannot be synced,
+so mistakes surface instead of being silently ignored. This happens when:
+
+- the package is not present in `uv.lock`
+  (usually a typo or a forgotten `uv add`),
+- the line has no dependency to sync
+  (the pragma landed on a comment or a non-dependency line), or
+- the line has more than one dependency
+  (only one dependency per pragma line is supported).
+
+All offending lines are reported together, with their line numbers,
+and the config file is left unchanged until they are fixed.
+
+Notes:
+
+- The package name is matched against `uv.lock` after
+  [PEP 503](https://peps.python.org/pep-0503/) normalization,
+  so `types-PyYAML` syncs with the `types-pyyaml` package.
+- The same pragma works in `prek.toml`:
+  `"pydantic>=2.0",  # sync-with-uv`.
+
 ## Advanced Configuration
 
 Most users don't need this section -

--- a/src/sync_with_uv/cli.py
+++ b/src/sync_with_uv/cli.py
@@ -10,7 +10,7 @@ from colorama import Fore, Style
 from cyclopts import App, Parameter
 
 from .repo_data import load_user_mappings
-from .sync_with_uv import load_uv_lock, process_config_text
+from .sync_with_uv import Changes, load_uv_lock, process_config_text
 
 app = App(name="sync-with-uv")
 app.register_install_completion_command()
@@ -146,7 +146,7 @@ def process_precommit(  # noqa: PLR0913
         )
         # report the results / change files
         if verbose:
-            _print_packages(changes)
+            _print_changes(changes)
         # output a diff to to stdout
         if diff:
             _print_diff(config_text, fixed_text, config_path, color=color)
@@ -163,14 +163,23 @@ def process_precommit(  # noqa: PLR0913
         return 123
 
 
-def _print_packages(changes: dict[str, bool | tuple[str, str]]) -> None:
-    for package, change in changes.items():
+def _print_changes(changes: Changes) -> None:
+    for package, change in changes.repos.items():
         if isinstance(change, tuple):
             print(f"{package}: {change[0]} -> {change[1]}", file=sys.stderr)
         elif change:
             print(f"{package}: unchanged", file=sys.stderr)
         else:
             print(f"{package}: not managed in uv", file=sys.stderr)
+    for line_number, dep in sorted(changes.lines.items()):
+        old_spec = dep.old_spec or "(unpinned)"
+        if dep.old_spec == dep.new_spec:
+            print(f"line {line_number}: {dep.package} unchanged", file=sys.stderr)
+        else:
+            print(
+                f"line {line_number}: {dep.package} {old_spec} -> {dep.new_spec}",
+                file=sys.stderr,
+            )
     print(file=sys.stderr)
 
 
@@ -195,21 +204,25 @@ def _plural(count: int, singular: str, plural: str) -> str:
     return singular if count == 1 else plural
 
 
-def _print_summary(
-    changes: dict[str, bool | tuple[str, str]], *, dry_mode: bool
-) -> None:
+def _print_summary(changes: Changes, *, dry_mode: bool) -> None:
     print("All done!", file=sys.stderr)
-    n_changed = n_unchanged = 0
-    for change in changes.values():
-        if isinstance(change, tuple):
-            n_changed += 1
-        else:
-            n_unchanged += 1
     would_be = "would be " if dry_mode else ""
+    n_pkg_changed = sum(isinstance(c, tuple) for c in changes.repos.values())
+    n_pkg_unchanged = len(changes.repos) - n_pkg_changed
     print(
-        f"{n_changed} {_plural(n_changed, 'package', 'packages')} "
+        f"{n_pkg_changed} {_plural(n_pkg_changed, 'package', 'packages')} "
         f"{would_be}changed, "
-        f"{n_unchanged} {_plural(n_unchanged, 'package', 'packages')} "
+        f"{n_pkg_unchanged} {_plural(n_pkg_unchanged, 'package', 'packages')} "
         f"{would_be}left unchanged.",
         file=sys.stderr,
     )
+    if changes.lines:
+        n_changed = sum(d.old_spec != d.new_spec for d in changes.lines.values())
+        n_unchanged = len(changes.lines) - n_changed
+        print(
+            f"{n_changed} {_plural(n_changed, 'dependency', 'dependencies')} "
+            f"{would_be}changed, "
+            f"{n_unchanged} {_plural(n_unchanged, 'dependency', 'dependencies')} "
+            f"{would_be}left unchanged.",
+            file=sys.stderr,
+        )

--- a/src/sync_with_uv/cli.py
+++ b/src/sync_with_uv/cli.py
@@ -172,14 +172,14 @@ def _print_changes(changes: Changes) -> None:
         else:
             print(f"{package}: not managed in uv", file=sys.stderr)
     for line_number, dep in sorted(changes.lines.items()):
-        old_spec = dep.old_spec or "(unpinned)"
-        if dep.old_spec == dep.new_spec:
-            print(f"line {line_number}: {dep.package} unchanged", file=sys.stderr)
-        else:
+        if dep.changed:
+            old_spec = dep.old_spec or "(unpinned)"
             print(
                 f"line {line_number}: {dep.package} {old_spec} -> {dep.new_spec}",
                 file=sys.stderr,
             )
+        else:
+            print(f"line {line_number}: {dep.package} unchanged", file=sys.stderr)
     print(file=sys.stderr)
 
 
@@ -217,7 +217,7 @@ def _print_summary(changes: Changes, *, dry_mode: bool) -> None:
         file=sys.stderr,
     )
     if changes.lines:
-        n_changed = sum(d.old_spec != d.new_spec for d in changes.lines.values())
+        n_changed = sum(d.changed for d in changes.lines.values())
         n_unchanged = len(changes.lines) - n_changed
         print(
             f"{n_changed} {_plural(n_changed, 'dependency', 'dependencies')} "

--- a/src/sync_with_uv/dependency_line.py
+++ b/src/sync_with_uv/dependency_line.py
@@ -1,0 +1,126 @@
+"""Sync a single ``# sync-with-uv`` dependency line with uv.lock."""
+
+import re
+from typing import NamedTuple
+
+# A dependency line is only synced when it carries this pragma comment,
+# e.g. ``- pydantic==2.0.0  # sync-with-uv``. The pragma is an explicit,
+# per-line opt-in, so the sync is safe regardless of where the line lives.
+_DEP_PRAGMA_RE = re.compile(r"#\s*sync-with-uv(?![\w-])")
+# A PEP 440 version specifier: one or more comma-separated ``<operator><version>``
+# clauses, e.g. ``==2.0.0`` or ``>=1.0,<2.0``.
+_DEP_OP = r"(?:===|==|~=|!=|<=|>=|<|>)"
+_DEP_VERSION = r"[0-9A-Za-z._*+!-]+"
+_DEP_CLAUSE = rf"{_DEP_OP}\s*{_DEP_VERSION}"
+_DEP_SPEC = rf"{_DEP_CLAUSE}(?:\s*,\s*{_DEP_CLAUSE})*"
+# A PEP 508 name, shared by the dependency matchers below.
+_DEP_NAME = r"[A-Za-z0-9][A-Za-z0-9._-]*"
+# A dependency item (YAML ``- `` dash or a quote) followed by a PEP 508 name and
+# optional extras, with a required version specifier. Matches ``- pydantic==2.0``.
+_DEP_LINE_RE = re.compile(
+    rf"""^
+    \s*(?:-\s+['"]?|['"])
+    (?P<name>{_DEP_NAME})
+    (?:\[[^\]]*\])?
+    \s*
+    (?P<spec>{_DEP_SPEC})
+    """,
+    re.VERBOSE,
+)
+# A dependency item with a name but no version specifier, e.g. ``- pydantic`` or
+# ``"pydantic",``. The name must be followed (via a zero-width lookahead, so the
+# match ends right after the name/extras and marks the insertion point) by a
+# bare-dependency terminator (closing quote, comma, marker, comment or end of
+# line) and never a ``:``, so structural lines such as ``rev:`` or ``- id: mypy``
+# are not matched.
+_DEP_BARE_RE = re.compile(
+    rf"""^
+    \s*(?:-\s+['"]?|['"])
+    (?P<name>{_DEP_NAME})
+    (?:\[[^\]]*\])?
+    (?=\s*(?:['"]|,|;|\#|$))
+    """,
+    re.VERBOSE,
+)
+# The only text allowed between the first dependency's specifier and its pragma
+# comment: whitespace, quotes and commas, then an optional ``;`` environment
+# marker (which may itself contain anything). Anything else -- another name or a
+# second quoted string -- means the line carries more than one dependency, of
+# which only the first would be synced.
+_DEP_TAIL_RE = re.compile(r"""[\s'",]*(?:;.*)?""")
+
+
+class DepLineChange(NamedTuple):
+    """A synced ``# sync-with-uv`` dependency line.
+
+    ``old_spec`` is the original version specifier (``""`` when the dependency
+    had none and a pin was added); ``new_spec`` is the applied ``==`` pin.
+    """
+
+    package: str
+    old_spec: str
+    new_spec: str
+
+    @property
+    def changed(self) -> bool:
+        """Whether the applied pin differs from the original specifier."""
+        return self.old_spec != self.new_spec
+
+
+def _normalize_package_name(name: str) -> str:
+    """Normalize a package name to its PEP 503 form (as used in uv.lock)."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def sync_dependency_line(
+    line: str, uv_data: dict[str, str]
+) -> tuple[str, DepLineChange] | str | None:
+    """Sync a dependency on a ``# sync-with-uv`` line.
+
+    The pragma is a strict, per-line opt-in: an annotated line must be a
+    dependency whose package is present in uv.lock. A dependency with a version
+    specifier has it replaced with an exact ``==`` pin
+    (``pydantic>=2.0`` -> ``pydantic==<locked>``); a bare dependency has a pin
+    added (``pydantic`` -> ``pydantic==<locked>``). The package name, extras,
+    quoting, environment markers and the comment itself are preserved.
+
+    Only one dependency per pragma line is supported; a line with more than one
+    is rejected rather than silently syncing only the first.
+
+    Args:
+        line: A single config line (with its line ending, if any).
+        uv_data: Package name to version mapping from uv.lock.
+
+    Returns:
+        ``None`` if the line does not carry the pragma. A tuple of (updated line,
+        :class:`DepLineChange`) when the dependency was processed. A ``str``
+        describing the problem when the annotated line is invalid (its package is
+        not in uv.lock, it has no dependency to sync, or it has more than one);
+        the caller collects these and raises.
+    """
+    pragma = _DEP_PRAGMA_RE.search(line)
+    if pragma is None:
+        return None
+    # Locate the dependency and the span of its version specifier. A specifier is
+    # replaced in place; a bare dependency has a pin inserted after its name, so
+    # its specifier span is the empty slice at the name's end.
+    spec_match = _DEP_LINE_RE.match(line)
+    if spec_match is not None:
+        name = spec_match.group("name")
+        old_spec = spec_match.group("spec")
+        spec_start, spec_end = spec_match.start("spec"), spec_match.end("spec")
+    else:
+        bare_match = _DEP_BARE_RE.match(line)
+        if bare_match is None:
+            return "no dependency to sync"
+        name = bare_match.group("name")
+        old_spec = ""
+        spec_start = spec_end = bare_match.end()
+    if not _DEP_TAIL_RE.fullmatch(line, spec_end, pragma.start()):
+        return "more than one dependency on the line; use one per line"
+    package = _normalize_package_name(name)
+    if package not in uv_data:
+        return f"{package!r} is not in uv.lock"
+    target_spec = f"=={uv_data[package]}"
+    line_fixed = line[:spec_start] + target_spec + line[spec_end:]
+    return line_fixed, DepLineChange(package, old_spec, target_spec)

--- a/src/sync_with_uv/sync_with_uv.py
+++ b/src/sync_with_uv/sync_with_uv.py
@@ -6,70 +6,8 @@ from typing import Literal, NamedTuple
 
 import tomli
 
+from sync_with_uv.dependency_line import DepLineChange, sync_dependency_line
 from sync_with_uv.repo_data import repo_to_package, repo_to_version_template
-
-# A dependency line is only synced when it carries this pragma comment,
-# e.g. ``- pydantic==2.0.0  # sync-with-uv``. The pragma is an explicit,
-# per-line opt-in, so the sync is safe regardless of where the line lives.
-_DEP_PRAGMA_RE = re.compile(r"#\s*sync-with-uv(?![\w-])")
-# A PEP 440 version specifier: one or more comma-separated ``<operator><version>``
-# clauses, e.g. ``==2.0.0`` or ``>=1.0,<2.0``.
-_DEP_OP = r"(?:===|==|~=|!=|<=|>=|<|>)"
-_DEP_VERSION = r"[0-9A-Za-z._*+!-]+"
-_DEP_CLAUSE = rf"{_DEP_OP}\s*{_DEP_VERSION}"
-_DEP_SPEC = rf"{_DEP_CLAUSE}(?:\s*,\s*{_DEP_CLAUSE})*"
-# A PEP 508 name, shared by the dependency matchers below.
-_DEP_NAME = r"[A-Za-z0-9][A-Za-z0-9._-]*"
-# A dependency item (YAML ``- `` dash or a quote) followed by a PEP 508 name and
-# optional extras, with a required version specifier. Matches ``- pydantic==2.0``.
-_DEP_LINE_RE = re.compile(
-    rf"""^
-    \s*(?:-\s+['"]?|['"])
-    (?P<name>{_DEP_NAME})
-    (?:\[[^\]]*\])?
-    \s*
-    (?P<spec>{_DEP_SPEC})
-    """,
-    re.VERBOSE,
-)
-# A dependency item with a name but no version specifier, e.g. ``- pydantic`` or
-# ``"pydantic",``. The name must be followed (via a zero-width lookahead, so the
-# match ends right after the name/extras and marks the insertion point) by a
-# bare-dependency terminator (closing quote, comma, marker, comment or end of
-# line) and never a ``:``, so structural lines such as ``rev:`` or ``- id: mypy``
-# are not matched.
-_DEP_BARE_RE = re.compile(
-    rf"""^
-    \s*(?:-\s+['"]?|['"])
-    (?P<name>{_DEP_NAME})
-    (?:\[[^\]]*\])?
-    (?=\s*(?:['"]|,|;|\#|$))
-    """,
-    re.VERBOSE,
-)
-# The only text allowed between the first dependency's specifier and its pragma
-# comment: whitespace, quotes and commas, then an optional ``;`` environment
-# marker (which may itself contain anything). Anything else -- another name or a
-# second quoted string -- means the line carries more than one dependency, of
-# which only the first would be synced.
-_DEP_TAIL_RE = re.compile(r"""[\s'",]*(?:;.*)?""")
-
-
-class DepLineChange(NamedTuple):
-    """A synced ``# sync-with-uv`` dependency line.
-
-    ``old_spec`` is the original version specifier (``""`` when the dependency
-    had none and a pin was added); ``new_spec`` is the applied ``==`` pin.
-    """
-
-    package: str
-    old_spec: str
-    new_spec: str
-
-    @property
-    def changed(self) -> bool:
-        """Whether the applied pin differs from the original specifier."""
-        return self.old_spec != self.new_spec
 
 
 class Changes(NamedTuple):
@@ -83,70 +21,6 @@ class Changes(NamedTuple):
 
     repos: dict[str, bool | tuple[str, str]]
     lines: dict[int, DepLineChange]
-
-
-def _replace_span(text: str, start: int, end: int, replacement: str) -> str:
-    """Replace ``text[start:end]`` with *replacement*, keeping the rest intact."""
-    return text[:start] + replacement + text[end:]
-
-
-def _normalize_package_name(name: str) -> str:
-    """Normalize a package name to its PEP 503 form (as used in uv.lock)."""
-    return re.sub(r"[-_.]+", "-", name).lower()
-
-
-def _sync_dependency_line(
-    line: str, uv_data: dict[str, str]
-) -> tuple[str, DepLineChange] | str | None:
-    """Sync a dependency on a ``# sync-with-uv`` line.
-
-    The pragma is a strict, per-line opt-in: an annotated line must be a
-    dependency whose package is present in uv.lock. A dependency with a version
-    specifier has it replaced with an exact ``==`` pin
-    (``pydantic>=2.0`` -> ``pydantic==<locked>``); a bare dependency has a pin
-    added (``pydantic`` -> ``pydantic==<locked>``). The package name, extras,
-    quoting, environment markers and the comment itself are preserved.
-
-    Only one dependency per pragma line is supported; a line with more than one
-    is rejected rather than silently syncing only the first.
-
-    Args:
-        line: A single config line (with its line ending, if any).
-        uv_data: Package name to version mapping from uv.lock.
-
-    Returns:
-        ``None`` if the line does not carry the pragma. A tuple of (updated line,
-        :class:`DepLineChange`) when the dependency was processed. A ``str``
-        describing the problem when the annotated line is invalid (its package is
-        not in uv.lock, it has no dependency to sync, or it has more than one);
-        the caller collects these and raises.
-    """
-    pragma = _DEP_PRAGMA_RE.search(line)
-    if pragma is None:
-        return None
-    # Locate the dependency and the span of its version specifier. A specifier is
-    # replaced in place; a bare dependency has a pin inserted after its name, so
-    # its specifier span is the empty slice at the name's end.
-    spec_match = _DEP_LINE_RE.match(line)
-    if spec_match is not None:
-        name = spec_match.group("name")
-        old_spec = spec_match.group("spec")
-        spec_start, spec_end = spec_match.start("spec"), spec_match.end("spec")
-    else:
-        bare_match = _DEP_BARE_RE.match(line)
-        if bare_match is None:
-            return "no dependency to sync"
-        name = bare_match.group("name")
-        old_spec = ""
-        spec_start = spec_end = bare_match.end()
-    if not _DEP_TAIL_RE.fullmatch(line, spec_end, pragma.start()):
-        return "more than one dependency on the line; use one per line"
-    package = _normalize_package_name(name)
-    if package not in uv_data:
-        return f"{package!r} is not in uv.lock"
-    target_spec = f"=={uv_data[package]}"
-    line_fixed = _replace_span(line, spec_start, spec_end, target_spec)
-    return line_fixed, DepLineChange(package, old_spec, target_spec)
 
 
 def load_uv_lock(filename: Path) -> dict[str, str]:
@@ -270,11 +144,10 @@ def process_config_text(
                     else "${version}"
                 )
             target_version = version_template.replace("${version}", uv_data[package])
-            line_fixed = _replace_span(
-                line,
-                repo_rev.start("repo_rev"),
-                repo_rev.end("repo_rev"),
-                target_version,
+            line_fixed = (
+                line[: repo_rev.start("repo_rev")]
+                + target_version
+                + line[repo_rev.end("repo_rev") :]
             )
             new_lines.append(line_fixed)
             repo_changes[package] = current_version == target_version or (
@@ -282,7 +155,7 @@ def process_config_text(
                 target_version,
             )
             continue  # don't add the line twice
-        elif (dep_result := _sync_dependency_line(line, uv_data)) is not None:
+        elif (dep_result := sync_dependency_line(line, uv_data)) is not None:
             if isinstance(dep_result, str):
                 dep_errors.append(f"line {line_number}: {dep_result}")
                 new_lines.append(line)

--- a/src/sync_with_uv/sync_with_uv.py
+++ b/src/sync_with_uv/sync_with_uv.py
@@ -2,11 +2,150 @@
 
 import re
 from pathlib import Path
-from typing import Literal
+from typing import Literal, NamedTuple
 
 import tomli
 
 from sync_with_uv.repo_data import repo_to_package, repo_to_version_template
+
+# A dependency line is only synced when it carries this pragma comment,
+# e.g. ``- pydantic==2.0.0  # sync-with-uv``. The pragma is an explicit,
+# per-line opt-in, so the sync is safe regardless of where the line lives.
+_DEP_PRAGMA_RE = re.compile(r"#\s*sync-with-uv(?![\w-])")
+# A PEP 440 version specifier: one or more comma-separated ``<operator><version>``
+# clauses, e.g. ``==2.0.0`` or ``>=1.0,<2.0``.
+_DEP_OP = r"(?:===|==|~=|!=|<=|>=|<|>)"
+_DEP_VERSION = r"[0-9A-Za-z._*+!-]+"
+_DEP_CLAUSE = rf"{_DEP_OP}\s*{_DEP_VERSION}"
+_DEP_SPEC = rf"{_DEP_CLAUSE}(?:\s*,\s*{_DEP_CLAUSE})*"
+# A dependency item (YAML ``- `` dash or a quote) followed by a PEP 508 name and
+# optional extras, with a required version specifier. Matches ``- pydantic==2.0``.
+_DEP_LINE_RE = re.compile(
+    rf"""^
+    (?P<prefix>\s*(?:-\s+['"]?|['"]))
+    (?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)
+    (?P<extras>\[[^\]]*\])?
+    \s*
+    (?P<spec>{_DEP_SPEC})
+    """,
+    re.VERBOSE,
+)
+# A dependency item with a name but no version specifier, e.g. ``- pydantic`` or
+# ``"pydantic",``. The name must be followed (via a zero-width lookahead, so the
+# match ends right after the name/extras and marks the insertion point) by a
+# bare-dependency terminator (closing quote, comma, marker, comment or end of
+# line) and never a ``:``, so structural lines such as ``rev:`` or ``- id: mypy``
+# are not matched.
+_DEP_BARE_RE = re.compile(
+    r"""^
+    \s*(?:-\s+['"]?|['"])
+    (?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)
+    (?P<extras>\[[^\]]*\])?
+    (?=\s*(?:['"]|,|;|\#|$))
+    """,
+    re.VERBOSE,
+)
+# A second dependency after the first one on the same line: a comma (the first
+# dependency's own specifier and extras are already consumed) followed by another
+# package name, optionally quoted. Used to reject lines with more than one
+# dependency, since only the first would be synced.
+_DEP_EXTRA_RE = re.compile(r""",\s*['"]?[A-Za-z0-9]""")
+
+
+class DepLineChange(NamedTuple):
+    """A synced ``# sync-with-uv`` dependency line.
+
+    ``old_spec`` is the original version specifier (``""`` when the dependency
+    had none and a pin was added); ``new_spec`` is the applied ``==`` pin. The
+    line is unchanged when ``old_spec == new_spec``.
+    """
+
+    package: str
+    old_spec: str
+    new_spec: str
+
+
+class Changes(NamedTuple):
+    """The changes made to a config, split by code path.
+
+    ``repos`` maps a package name to True (rev already correct), False (repo not
+    linked to a uv.lock package) or a (old_rev, new_rev) tuple, and a repo URL
+    to False when it has no package mapping. ``lines`` maps a 1-based line
+    number to the :class:`DepLineChange` applied to that dependency line.
+    """
+
+    repos: dict[str, bool | tuple[str, str]]
+    lines: dict[int, DepLineChange]
+
+
+class _DepSyncResult(NamedTuple):
+    """A successfully processed pragma dependency line."""
+
+    line: str
+    package: str
+    old_spec: str
+    new_spec: str
+
+
+def _normalize_package_name(name: str) -> str:
+    """Normalize a package name to its PEP 503 form (as used in uv.lock)."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _sync_dependency_line(
+    line: str, uv_data: dict[str, str]
+) -> _DepSyncResult | str | None:
+    """Sync a dependency on a ``# sync-with-uv`` line.
+
+    The pragma is a strict, per-line opt-in: an annotated line must be a
+    dependency whose package is present in uv.lock. A dependency with a version
+    specifier has it replaced with an exact ``==`` pin
+    (``pydantic>=2.0`` -> ``pydantic==<locked>``); a bare dependency has a pin
+    added (``pydantic`` -> ``pydantic==<locked>``). The package name, extras,
+    quoting, environment markers and the comment itself are preserved.
+
+    Args:
+        line: A single config line (with its line ending, if any).
+        uv_data: Package name to version mapping from uv.lock.
+
+    Only one dependency per pragma line is supported; a line with more than one
+    is rejected rather than silently syncing only the first.
+
+    Returns:
+        ``None`` if the line does not carry the pragma. A :class:`_DepSyncResult`
+        (updated line, package, old specifier, new specifier) when the dependency
+        was processed; the old specifier is ``""`` when a pin was added, and the
+        line is unchanged when old and new specifiers match. A ``str`` describing
+        the problem when the annotated line is invalid (its package is not in
+        uv.lock, it has no dependency to sync, or it has more than one); the
+        caller collects these and raises.
+    """
+    pragma = _DEP_PRAGMA_RE.search(line)
+    if pragma is None:
+        return None
+    # Locate the dependency and the span of its version specifier. A specifier is
+    # replaced in place; a bare dependency has a pin inserted after its name, so
+    # its specifier span is the empty slice at the name's end.
+    spec_match = _DEP_LINE_RE.match(line)
+    if spec_match is not None:
+        name = spec_match.group("name")
+        old_spec = spec_match.group("spec")
+        spec_start, spec_end = spec_match.start("spec"), spec_match.end("spec")
+    else:
+        bare_match = _DEP_BARE_RE.match(line)
+        if bare_match is None:
+            return "no dependency to sync"
+        name = bare_match.group("name")
+        old_spec = ""
+        spec_start = spec_end = bare_match.end()
+    if _DEP_EXTRA_RE.search(line, spec_end, pragma.start()):
+        return "more than one dependency on the line; use one per line"
+    package = _normalize_package_name(name)
+    if package not in uv_data:
+        return f"{package!r} is not in uv.lock"
+    target_spec = f"=={uv_data[package]}"
+    line_fixed = line[:spec_start] + target_spec + line[spec_end:]
+    return _DepSyncResult(line_fixed, package, old_spec, target_spec)
 
 
 def load_uv_lock(filename: Path) -> dict[str, str]:
@@ -31,6 +170,31 @@ def load_uv_lock(filename: Path) -> dict[str, str]:
     )
 
 
+def _repo_header_package(
+    repo_url: str,
+    uv_data: dict[str, str],
+    skip_repos: set[str],
+    user_repo_mappings: dict[str, str] | None,
+    repo_changes: dict[str, bool | tuple[str, str]],
+) -> str | None:
+    """Resolve the package linked to a repo header.
+
+    Records unmanaged repos and packages absent from uv.lock in *repo_changes*.
+
+    Returns:
+        The package name to sync the repo's ``rev`` against, or ``None`` when
+        the repo has no linked package in uv.lock.
+    """
+    package = repo_to_package(repo_url, user_repo_mappings)
+    if not package:
+        if repo_url not in skip_repos:
+            repo_changes[repo_url] = False
+        return None
+    if package not in uv_data:
+        repo_changes[package] = False
+    return package
+
+
 def process_config_text(
     config_text: str,
     uv_data: dict[str, str],
@@ -38,10 +202,17 @@ def process_config_text(
     config_format: Literal["yaml", "toml"],
     user_repo_mappings: dict[str, str] | None = None,
     user_version_mappings: dict[str, str] | None = None,
-) -> tuple[str, dict[str, bool | tuple[str, str]]]:
+) -> tuple[str, Changes]:
     """Process config text and sync versions with uv.lock.
 
     Shared implementation for both .pre-commit-config.yaml and prek.toml.
+
+    The ``rev`` field of every repo linked to a uv.lock package is synced.
+    In addition, any dependency line (such as an ``additional_dependencies``
+    entry) that carries a ``# sync-with-uv`` pragma comment is pinned to the
+    exact uv.lock version, adding an ``==`` specifier if the dependency has
+    none. The pragma is a strict opt-in: an annotated line must be a dependency
+    whose package is in uv.lock, otherwise a :class:`ValueError` is raised.
 
     Args:
         config_text: Raw config file content.
@@ -52,10 +223,15 @@ def process_config_text(
         user_version_mappings: Optional user repo-to-version-template mappings.
 
     Returns:
-        Tuple of (updated_config_text, changes_dict) where changes_dict maps:
-        - package names to True (unchanged), False (not in uv.lock), or
-          tuple of (old_version, new_version) when changed
-        - repo URLs to False when no package mapping exists
+        Tuple of (updated_config_text, changes), where ``changes`` is a
+        :class:`Changes` with ``repos`` (per-package ``rev`` results) and
+        ``lines`` (per-line-number dependency-pin results). The two code paths
+        are kept separate so that a package synced on several dependency lines
+        is reported once per line rather than collapsed to a single entry.
+
+    Raises:
+        ValueError: If a ``# sync-with-uv`` line has no dependency to sync, or
+            its package is not present in uv.lock.
     """
     repo_header_re = {
         "yaml": re.compile(r"^\s*-\s*repo\s*:\s*(?P<repo_url>\S*).*$"),
@@ -73,16 +249,15 @@ def process_config_text(
     new_lines: list[str] = []
     repo_url: str | None = None
     package: str | None = None
-    changes: dict[str, bool | tuple[str, str]] = {}
-    for line in lines:
+    repo_changes: dict[str, bool | tuple[str, str]] = {}
+    dep_changes: dict[int, DepLineChange] = {}
+    dep_errors: list[str] = []
+    for line_number, line in enumerate(lines, start=1):
         if repo_header := repo_header_re.match(line):
             repo_url = repo_header.group("repo_url")
-            package = repo_to_package(repo_url, user_repo_mappings)
-            if not package:
-                if repo_url not in skip_repos:
-                    changes[repo_url] = False
-            elif package not in uv_data:
-                changes[package] = False
+            package = _repo_header_package(
+                repo_url, uv_data, skip_repos, user_repo_mappings, repo_changes
+            )
         elif package and package in uv_data and (repo_rev := repo_rev_re.match(line)):
             assert repo_url is not None  # noqa: S101
             version_template = repo_to_version_template(repo_url, user_version_mappings)
@@ -100,11 +275,24 @@ def process_config_text(
                 + line[repo_rev.end("repo_rev") :]
             )
             new_lines.append(line_fixed)
-            changes[package] = current_version == target_version or (
+            repo_changes[package] = current_version == target_version or (
                 current_version,
                 target_version,
             )
             continue  # don't add the line twice
+        elif (dep_result := _sync_dependency_line(line, uv_data)) is not None:
+            if isinstance(dep_result, str):
+                dep_errors.append(f"line {line_number}: {dep_result}")
+                new_lines.append(line)
+            else:
+                dep_changes[line_number] = DepLineChange(
+                    dep_result.package, dep_result.old_spec, dep_result.new_spec
+                )
+                new_lines.append(dep_result.line)
+            continue  # don't add the line twice
         new_lines.append(line)
 
-    return "".join(new_lines), changes
+    if dep_errors:
+        msg = "invalid '# sync-with-uv' dependencies:\n  " + "\n  ".join(dep_errors)
+        raise ValueError(msg)
+    return "".join(new_lines), Changes(repo_changes, dep_changes)

--- a/src/sync_with_uv/sync_with_uv.py
+++ b/src/sync_with_uv/sync_with_uv.py
@@ -18,13 +18,15 @@ _DEP_OP = r"(?:===|==|~=|!=|<=|>=|<|>)"
 _DEP_VERSION = r"[0-9A-Za-z._*+!-]+"
 _DEP_CLAUSE = rf"{_DEP_OP}\s*{_DEP_VERSION}"
 _DEP_SPEC = rf"{_DEP_CLAUSE}(?:\s*,\s*{_DEP_CLAUSE})*"
+# A PEP 508 name, shared by the dependency matchers below.
+_DEP_NAME = r"[A-Za-z0-9][A-Za-z0-9._-]*"
 # A dependency item (YAML ``- `` dash or a quote) followed by a PEP 508 name and
 # optional extras, with a required version specifier. Matches ``- pydantic==2.0``.
 _DEP_LINE_RE = re.compile(
     rf"""^
-    (?P<prefix>\s*(?:-\s+['"]?|['"]))
-    (?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)
-    (?P<extras>\[[^\]]*\])?
+    \s*(?:-\s+['"]?|['"])
+    (?P<name>{_DEP_NAME})
+    (?:\[[^\]]*\])?
     \s*
     (?P<spec>{_DEP_SPEC})
     """,
@@ -37,32 +39,37 @@ _DEP_LINE_RE = re.compile(
 # line) and never a ``:``, so structural lines such as ``rev:`` or ``- id: mypy``
 # are not matched.
 _DEP_BARE_RE = re.compile(
-    r"""^
+    rf"""^
     \s*(?:-\s+['"]?|['"])
-    (?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)
-    (?P<extras>\[[^\]]*\])?
+    (?P<name>{_DEP_NAME})
+    (?:\[[^\]]*\])?
     (?=\s*(?:['"]|,|;|\#|$))
     """,
     re.VERBOSE,
 )
-# A second dependency after the first one on the same line: a comma (the first
-# dependency's own specifier and extras are already consumed) followed by another
-# package name, optionally quoted. Used to reject lines with more than one
-# dependency, since only the first would be synced.
-_DEP_EXTRA_RE = re.compile(r""",\s*['"]?[A-Za-z0-9]""")
+# The only text allowed between the first dependency's specifier and its pragma
+# comment: whitespace, quotes and commas, then an optional ``;`` environment
+# marker (which may itself contain anything). Anything else -- another name or a
+# second quoted string -- means the line carries more than one dependency, of
+# which only the first would be synced.
+_DEP_TAIL_RE = re.compile(r"""[\s'",]*(?:;.*)?""")
 
 
 class DepLineChange(NamedTuple):
     """A synced ``# sync-with-uv`` dependency line.
 
     ``old_spec`` is the original version specifier (``""`` when the dependency
-    had none and a pin was added); ``new_spec`` is the applied ``==`` pin. The
-    line is unchanged when ``old_spec == new_spec``.
+    had none and a pin was added); ``new_spec`` is the applied ``==`` pin.
     """
 
     package: str
     old_spec: str
     new_spec: str
+
+    @property
+    def changed(self) -> bool:
+        """Whether the applied pin differs from the original specifier."""
+        return self.old_spec != self.new_spec
 
 
 class Changes(NamedTuple):
@@ -78,13 +85,9 @@ class Changes(NamedTuple):
     lines: dict[int, DepLineChange]
 
 
-class _DepSyncResult(NamedTuple):
-    """A successfully processed pragma dependency line."""
-
-    line: str
-    package: str
-    old_spec: str
-    new_spec: str
+def _replace_span(text: str, start: int, end: int, replacement: str) -> str:
+    """Replace ``text[start:end]`` with *replacement*, keeping the rest intact."""
+    return text[:start] + replacement + text[end:]
 
 
 def _normalize_package_name(name: str) -> str:
@@ -94,7 +97,7 @@ def _normalize_package_name(name: str) -> str:
 
 def _sync_dependency_line(
     line: str, uv_data: dict[str, str]
-) -> _DepSyncResult | str | None:
+) -> tuple[str, DepLineChange] | str | None:
     """Sync a dependency on a ``# sync-with-uv`` line.
 
     The pragma is a strict, per-line opt-in: an annotated line must be a
@@ -104,21 +107,19 @@ def _sync_dependency_line(
     added (``pydantic`` -> ``pydantic==<locked>``). The package name, extras,
     quoting, environment markers and the comment itself are preserved.
 
+    Only one dependency per pragma line is supported; a line with more than one
+    is rejected rather than silently syncing only the first.
+
     Args:
         line: A single config line (with its line ending, if any).
         uv_data: Package name to version mapping from uv.lock.
 
-    Only one dependency per pragma line is supported; a line with more than one
-    is rejected rather than silently syncing only the first.
-
     Returns:
-        ``None`` if the line does not carry the pragma. A :class:`_DepSyncResult`
-        (updated line, package, old specifier, new specifier) when the dependency
-        was processed; the old specifier is ``""`` when a pin was added, and the
-        line is unchanged when old and new specifiers match. A ``str`` describing
-        the problem when the annotated line is invalid (its package is not in
-        uv.lock, it has no dependency to sync, or it has more than one); the
-        caller collects these and raises.
+        ``None`` if the line does not carry the pragma. A tuple of (updated line,
+        :class:`DepLineChange`) when the dependency was processed. A ``str``
+        describing the problem when the annotated line is invalid (its package is
+        not in uv.lock, it has no dependency to sync, or it has more than one);
+        the caller collects these and raises.
     """
     pragma = _DEP_PRAGMA_RE.search(line)
     if pragma is None:
@@ -138,14 +139,14 @@ def _sync_dependency_line(
         name = bare_match.group("name")
         old_spec = ""
         spec_start = spec_end = bare_match.end()
-    if _DEP_EXTRA_RE.search(line, spec_end, pragma.start()):
+    if not _DEP_TAIL_RE.fullmatch(line, spec_end, pragma.start()):
         return "more than one dependency on the line; use one per line"
     package = _normalize_package_name(name)
     if package not in uv_data:
         return f"{package!r} is not in uv.lock"
     target_spec = f"=={uv_data[package]}"
-    line_fixed = line[:spec_start] + target_spec + line[spec_end:]
-    return _DepSyncResult(line_fixed, package, old_spec, target_spec)
+    line_fixed = _replace_span(line, spec_start, spec_end, target_spec)
+    return line_fixed, DepLineChange(package, old_spec, target_spec)
 
 
 def load_uv_lock(filename: Path) -> dict[str, str]:
@@ -269,10 +270,11 @@ def process_config_text(
                     else "${version}"
                 )
             target_version = version_template.replace("${version}", uv_data[package])
-            line_fixed = (
-                line[: repo_rev.start("repo_rev")]
-                + target_version
-                + line[repo_rev.end("repo_rev") :]
+            line_fixed = _replace_span(
+                line,
+                repo_rev.start("repo_rev"),
+                repo_rev.end("repo_rev"),
+                target_version,
             )
             new_lines.append(line_fixed)
             repo_changes[package] = current_version == target_version or (
@@ -285,10 +287,8 @@ def process_config_text(
                 dep_errors.append(f"line {line_number}: {dep_result}")
                 new_lines.append(line)
             else:
-                dep_changes[line_number] = DepLineChange(
-                    dep_result.package, dep_result.old_spec, dep_result.new_spec
-                )
-                new_lines.append(dep_result.line)
+                line_fixed, dep_changes[line_number] = dep_result
+                new_lines.append(line_fixed)
             continue  # don't add the line twice
         new_lines.append(line)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -208,8 +208,7 @@ def test_process_precommit_cli_check_no_changes_needed(
     """Test CLI check mode when files are already synchronized (returns code 0)."""
     # Create uv.lock with package versions
     uv_lock_file = tmp_path / "uv.lock"
-    uv_lock_file.write_text(
-        textwrap.dedent("""
+    uv_lock_file.write_text(textwrap.dedent("""
             [[package]]
             name = "black"
             version = "23.11.0"
@@ -217,13 +216,11 @@ def test_process_precommit_cli_check_no_changes_needed(
             [[package]]
             name = "ruff"
             version = "0.1.5"
-            """)
-    )
+            """))
 
     # Create pre-commit config that matches uv.lock versions
     precommit_file = tmp_path / ".pre-commit-config.yaml"
-    precommit_file.write_text(
-        textwrap.dedent("""\
+    precommit_file.write_text(textwrap.dedent("""\
             repos:
             - repo: https://github.com/psf/black-pre-commit-mirror
               rev: 23.11.0
@@ -233,8 +230,7 @@ def test_process_precommit_cli_check_no_changes_needed(
               rev: v0.1.5
               hooks:
                 - id: ruff
-            """)
-    )
+            """))
 
     with pytest.raises(SystemExit) as exc_info:
         app(["-p", str(precommit_file), "-u", str(uv_lock_file), "--check"])
@@ -284,24 +280,20 @@ def test_cli_write_permission_error(
     """Test CLI handles file write permission errors."""
     # Create valid files
     uv_lock_file = tmp_path / "uv.lock"
-    uv_lock_file.write_text(
-        textwrap.dedent("""
+    uv_lock_file.write_text(textwrap.dedent("""
             [[package]]
             name = "black"
             version = "23.11.0"
-            """)
-    )
+            """))
 
     precommit_file = tmp_path / ".pre-commit-config.yaml"
-    precommit_file.write_text(
-        textwrap.dedent("""\
+    precommit_file.write_text(textwrap.dedent("""\
             repos:
             - repo: https://github.com/psf/black-pre-commit-mirror
               rev: 23.9.1
               hooks:
                 - id: black
-            """)
-    )
+            """))
 
     # Make the pre-commit file read-only
     precommit_file.chmod(0o444)
@@ -343,13 +335,11 @@ def test_cli_missing_precommit_config(
 ) -> None:
     """Test CLI handles missing pre-commit config file."""
     uv_lock_file = tmp_path / "uv.lock"
-    uv_lock_file.write_text(
-        textwrap.dedent("""
+    uv_lock_file.write_text(textwrap.dedent("""
             [[package]]
             name = "black"
             version = "23.11.0"
-            """)
-    )
+            """))
 
     nonexistent_precommit = tmp_path / "nonexistent.yaml"
 
@@ -372,13 +362,11 @@ def test_cli_preserves_line_endings_when_writing(
     """Test CLI preserves line endings when writing files (issue #24)."""
     # Create uv.lock with package version
     uv_lock_file = tmp_path / "uv.lock"
-    uv_lock_file.write_text(
-        textwrap.dedent("""
+    uv_lock_file.write_text(textwrap.dedent("""
             [[package]]
             name = "black"
             version = "24.0.0"
-            """)
-    )
+            """))
 
     # Create pre-commit config with specific line endings
     precommit_file = tmp_path / ".pre-commit-config.yaml"
@@ -413,19 +401,16 @@ def test_cli_reports_dependency_line_changes(
 ) -> None:
     """The CLI reports per-line dependency pins separately from per-package revs."""
     uv_lock_file = tmp_path / "uv.lock"
-    uv_lock_file.write_text(
-        textwrap.dedent("""\
+    uv_lock_file.write_text(textwrap.dedent("""\
             [[package]]
             name = "mypy"
             version = "1.8.0"
             [[package]]
             name = "pydantic"
             version = "2.5.0"
-            """)
-    )
+            """))
     precommit_file = tmp_path / ".pre-commit-config.yaml"
-    precommit_file.write_text(
-        textwrap.dedent("""\
+    precommit_file.write_text(textwrap.dedent("""\
             repos:
             - repo: https://github.com/pre-commit/mirrors-mypy
               rev: v1.5.1
@@ -434,8 +419,7 @@ def test_cli_reports_dependency_line_changes(
                   additional_dependencies:
                     - pydantic>=2.0  # sync-with-uv
                     - pydantic  # sync-with-uv
-            """)
-    )
+            """))
 
     with pytest.raises(SystemExit) as exc_info:
         app(["-p", str(precommit_file), "-u", str(uv_lock_file), "-v"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -208,7 +208,8 @@ def test_process_precommit_cli_check_no_changes_needed(
     """Test CLI check mode when files are already synchronized (returns code 0)."""
     # Create uv.lock with package versions
     uv_lock_file = tmp_path / "uv.lock"
-    uv_lock_file.write_text(textwrap.dedent("""
+    uv_lock_file.write_text(
+        textwrap.dedent("""
             [[package]]
             name = "black"
             version = "23.11.0"
@@ -216,11 +217,13 @@ def test_process_precommit_cli_check_no_changes_needed(
             [[package]]
             name = "ruff"
             version = "0.1.5"
-            """))
+            """)
+    )
 
     # Create pre-commit config that matches uv.lock versions
     precommit_file = tmp_path / ".pre-commit-config.yaml"
-    precommit_file.write_text(textwrap.dedent("""\
+    precommit_file.write_text(
+        textwrap.dedent("""\
             repos:
             - repo: https://github.com/psf/black-pre-commit-mirror
               rev: 23.11.0
@@ -230,7 +233,8 @@ def test_process_precommit_cli_check_no_changes_needed(
               rev: v0.1.5
               hooks:
                 - id: ruff
-            """))
+            """)
+    )
 
     with pytest.raises(SystemExit) as exc_info:
         app(["-p", str(precommit_file), "-u", str(uv_lock_file), "--check"])
@@ -280,20 +284,24 @@ def test_cli_write_permission_error(
     """Test CLI handles file write permission errors."""
     # Create valid files
     uv_lock_file = tmp_path / "uv.lock"
-    uv_lock_file.write_text(textwrap.dedent("""
+    uv_lock_file.write_text(
+        textwrap.dedent("""
             [[package]]
             name = "black"
             version = "23.11.0"
-            """))
+            """)
+    )
 
     precommit_file = tmp_path / ".pre-commit-config.yaml"
-    precommit_file.write_text(textwrap.dedent("""\
+    precommit_file.write_text(
+        textwrap.dedent("""\
             repos:
             - repo: https://github.com/psf/black-pre-commit-mirror
               rev: 23.9.1
               hooks:
                 - id: black
-            """))
+            """)
+    )
 
     # Make the pre-commit file read-only
     precommit_file.chmod(0o444)
@@ -335,11 +343,13 @@ def test_cli_missing_precommit_config(
 ) -> None:
     """Test CLI handles missing pre-commit config file."""
     uv_lock_file = tmp_path / "uv.lock"
-    uv_lock_file.write_text(textwrap.dedent("""
+    uv_lock_file.write_text(
+        textwrap.dedent("""
             [[package]]
             name = "black"
             version = "23.11.0"
-            """))
+            """)
+    )
 
     nonexistent_precommit = tmp_path / "nonexistent.yaml"
 
@@ -362,11 +372,13 @@ def test_cli_preserves_line_endings_when_writing(
     """Test CLI preserves line endings when writing files (issue #24)."""
     # Create uv.lock with package version
     uv_lock_file = tmp_path / "uv.lock"
-    uv_lock_file.write_text(textwrap.dedent("""
+    uv_lock_file.write_text(
+        textwrap.dedent("""
             [[package]]
             name = "black"
             version = "24.0.0"
-            """))
+            """)
+    )
 
     # Create pre-commit config with specific line endings
     precommit_file = tmp_path / ".pre-commit-config.yaml"
@@ -394,3 +406,48 @@ def test_cli_preserves_line_endings_when_writing(
         precommit_content_bytes.replace(b"23.11.0", b"24.0.0")
         == precommit_file.read_bytes()
     )
+
+
+def test_cli_reports_dependency_line_changes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The CLI reports per-line dependency pins separately from per-package revs."""
+    uv_lock_file = tmp_path / "uv.lock"
+    uv_lock_file.write_text(
+        textwrap.dedent("""\
+            [[package]]
+            name = "mypy"
+            version = "1.8.0"
+            [[package]]
+            name = "pydantic"
+            version = "2.5.0"
+            """)
+    )
+    precommit_file = tmp_path / ".pre-commit-config.yaml"
+    precommit_file.write_text(
+        textwrap.dedent("""\
+            repos:
+            - repo: https://github.com/pre-commit/mirrors-mypy
+              rev: v1.5.1
+              hooks:
+                - id: mypy
+                  additional_dependencies:
+                    - pydantic>=2.0  # sync-with-uv
+                    - pydantic  # sync-with-uv
+            """)
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        app(["-p", str(precommit_file), "-u", str(uv_lock_file), "-v"])
+    assert exc_info.value.code == 0
+    err = capsys.readouterr().err
+    # the rev is a per-package change; the two pydantic deps are per-line changes
+    # (reported separately even though they are the same package)
+    assert "mypy: v1.5.1 -> v1.8.0" in err
+    assert "line 7: pydantic >=2.0 -> ==2.5.0" in err
+    assert "line 8: pydantic (unpinned) -> ==2.5.0" in err
+    assert "1 package changed, 0 packages left unchanged." in err
+    assert "2 dependencies changed, 0 dependencies left unchanged." in err
+
+    content = precommit_file.read_text()
+    assert content.count("- pydantic==2.5.0  # sync-with-uv\n") == 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -435,3 +435,31 @@ def test_cli_reports_dependency_line_changes(
 
     content = precommit_file.read_text()
     assert content.count("- pydantic==2.5.0  # sync-with-uv\n") == 2
+
+
+def test_cli_reports_unchanged_dependency_line(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A pragma dependency already at the locked version is reported as unchanged."""
+    uv_lock_file = tmp_path / "uv.lock"
+    uv_lock_file.write_text(textwrap.dedent("""\
+            [[package]]
+            name = "pydantic"
+            version = "2.5.0"
+            """))
+    precommit_file = tmp_path / ".pre-commit-config.yaml"
+    precommit_file.write_text(textwrap.dedent("""\
+            repos:
+            - repo: local
+              hooks:
+                - id: mypy
+                  additional_dependencies:
+                    - pydantic==2.5.0  # sync-with-uv
+            """))
+
+    with pytest.raises(SystemExit) as exc_info:
+        app(["-p", str(precommit_file), "-u", str(uv_lock_file), "-v"])
+    assert exc_info.value.code == 0
+    err = capsys.readouterr().err
+    assert "line 6: pydantic unchanged" in err
+    assert "0 dependencies changed, 1 dependency left unchanged." in err

--- a/tests/test_prek.py
+++ b/tests/test_prek.py
@@ -286,6 +286,28 @@ def test_sync_additional_dependencies_toml_bare_adds_specifier() -> None:
     }
 
 
+def test_sync_additional_dependencies_toml_bare_adds_specifier_with_marker() -> None:
+    """A bare pragma dependency with a marker in prek.toml pins before the marker."""
+    prek_text = textwrap.dedent("""\
+        [[repos.hooks]]
+        id = "mypy"
+        additional_dependencies = [
+          'types-PyYAML ; python_version < "3.11"',  # sync-with-uv
+        ]
+        """)
+    uv_data = {"types-pyyaml": "6.0.1"}
+
+    result, changes = process_config_text(prek_text, uv_data, config_format="toml")
+
+    assert (
+        "  'types-PyYAML==6.0.1 ; python_version < \"3.11\"',  # sync-with-uv" in result
+    )
+    assert changes.repos == {}
+    assert changes.lines == {
+        4: ("types-pyyaml", "", "==6.0.1"),
+    }
+
+
 def test_sync_additional_dependencies_toml_errors() -> None:
     """Invalid pragma dependencies in prek.toml are reported as errors."""
     prek_text = textwrap.dedent("""\

--- a/tests/test_prek.py
+++ b/tests/test_prek.py
@@ -132,19 +132,21 @@ def test_process_prek_toml_text(sample_prek_config: Path, sample_uv_lock: Path) 
     uv_data = load_uv_lock(sample_uv_lock)
     result, changes = process_config_text(prek_text, uv_data, config_format="toml")
     assert result == FIXED_PREK_CONTENT
-    assert changes == {
+    assert changes.repos == {
         "ruff": ("v0.14.0", "v0.15.0"),
         "gitleaks": ("v8.30.0", "v8.31.0"),
         "typos": ("v1.43.3", "v1.44.0"),
         "unknown-tool": False,
     }
+    assert changes.lines == {}
 
 
 def test_process_prek_toml_text_empty() -> None:
     """Test processing an empty prek.toml."""
     result, changes = process_config_text("", {"ruff": "0.15.0"}, config_format="toml")
     assert result == ""
-    assert changes == {}
+    assert changes.repos == {}
+    assert changes.lines == {}
 
 
 def test_process_prek_toml_text_no_changes_needed() -> None:
@@ -158,7 +160,8 @@ def test_process_prek_toml_text_no_changes_needed() -> None:
     uv_data = {"ruff": "0.15.0"}
     result, changes = process_config_text(prek_text, uv_data, config_format="toml")
     assert result == prek_text
-    assert changes == {"ruff": True}
+    assert changes.repos == {"ruff": True}
+    assert changes.lines == {}
 
 
 def test_process_prek_toml_text_single_quotes() -> None:
@@ -172,7 +175,8 @@ def test_process_prek_toml_text_single_quotes() -> None:
     uv_data = {"ruff": "0.15.0"}
     result, changes = process_config_text(prek_text, uv_data, config_format="toml")
     assert "rev = 'v0.15.0'" in result
-    assert changes == {"ruff": ("v0.14.0", "v0.15.0")}
+    assert changes.repos == {"ruff": ("v0.14.0", "v0.15.0")}
+    assert changes.lines == {}
 
 
 def test_process_prek_toml_text_builtin_and_local_skipped() -> None:
@@ -193,7 +197,8 @@ def test_process_prek_toml_text_builtin_and_local_skipped() -> None:
     uv_data = {"ruff": "0.15.0"}
     result, changes = process_config_text(prek_text, uv_data, config_format="toml")
     assert result == prek_text
-    assert changes == {}
+    assert changes.repos == {}
+    assert changes.lines == {}
 
 
 def test_process_prek_toml_text_with_user_mappings() -> None:
@@ -221,10 +226,101 @@ def test_process_prek_toml_text_with_user_mappings() -> None:
     )
     assert 'rev = "v2.1.0"' in result
     assert 'rev = "v0.15.0"' in result
-    assert changes == {
+    assert changes.repos == {
         "custom-tool": ("v1.0.0", "v2.1.0"),
         "ruff": ("v0.14.0", "v0.15.0"),
     }
+    assert changes.lines == {}
+
+
+def test_sync_additional_dependencies_pragma_toml() -> None:
+    """Pragma-annotated dependencies in a multi-line TOML array are pinned."""
+    prek_text = textwrap.dedent("""\
+        [[repos]]
+        repo = "https://github.com/pre-commit/mirrors-mypy"
+        rev = "v1.5.1"
+
+        [[repos.hooks]]
+        id = "mypy"
+        additional_dependencies = [
+          "pydantic>=2.0",  # sync-with-uv
+          'types-PyYAML==6.0.0',  # sync-with-uv
+          "rich>=10",
+        ]
+        """)
+    uv_data = {"mypy": "1.5.1", "pydantic": "2.5.0", "types-pyyaml": "6.0.1"}
+
+    result, changes = process_config_text(prek_text, uv_data, config_format="toml")
+
+    assert '  "pydantic==2.5.0",  # sync-with-uv' in result
+    assert "  'types-PyYAML==6.0.1',  # sync-with-uv" in result
+    # lines without a pragma are never touched
+    assert '  "rich>=10",' in result
+    assert changes.repos == {"mypy": True}
+    assert changes.lines == {
+        8: ("pydantic", ">=2.0", "==2.5.0"),
+        9: ("types-pyyaml", "==6.0.0", "==6.0.1"),
+    }
+
+
+def test_sync_additional_dependencies_toml_bare_adds_specifier() -> None:
+    """A bare pragma dependency in prek.toml gets an exact pin added."""
+    prek_text = textwrap.dedent("""\
+        [[repos.hooks]]
+        id = "mypy"
+        additional_dependencies = [
+          "pydantic",  # sync-with-uv
+          'attrs>=1',  # sync-with-uv
+        ]
+        """)
+    uv_data = {"pydantic": "2.5.0", "attrs": "23.2.0"}
+
+    result, changes = process_config_text(prek_text, uv_data, config_format="toml")
+
+    assert '  "pydantic==2.5.0",  # sync-with-uv' in result
+    assert "  'attrs==23.2.0',  # sync-with-uv" in result
+    assert changes.repos == {}
+    assert changes.lines == {
+        4: ("pydantic", "", "==2.5.0"),
+        5: ("attrs", ">=1", "==23.2.0"),
+    }
+
+
+def test_sync_additional_dependencies_toml_errors() -> None:
+    """Invalid pragma dependencies in prek.toml are reported as errors."""
+    prek_text = textwrap.dedent("""\
+        [[repos.hooks]]
+        id = "mypy"
+        additional_dependencies = [
+          # sync-with-uv
+          "not-locked==1.0.0",  # sync-with-uv
+        ]
+        """)
+    uv_data = {"pydantic": "2.5.0"}
+
+    with pytest.raises(
+        ValueError, match="invalid '# sync-with-uv' dependencies"
+    ) as exc_info:
+        process_config_text(prek_text, uv_data, config_format="toml")
+    message = str(exc_info.value)
+    assert "line 4: no dependency to sync" in message
+    assert "line 5: 'not-locked' is not in uv.lock" in message
+
+
+def test_sync_additional_dependencies_toml_multiple_on_line_errors() -> None:
+    """More than one dependency on a pragma line is rejected in prek.toml too."""
+    prek_text = textwrap.dedent("""\
+        [[repos.hooks]]
+        id = "mypy"
+        additional_dependencies = [
+          "pydantic==2.0", "attrs>=1",  # sync-with-uv
+        ]
+        """)
+    uv_data = {"pydantic": "2.5.0", "attrs": "23.2.0"}
+
+    with pytest.raises(ValueError, match="more than one dependency") as exc_info:
+        process_config_text(prek_text, uv_data, config_format="toml")
+    assert "line 4" in str(exc_info.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -601,3 +601,27 @@ def test_sync_additional_dependencies_already_pinned() -> None:
     # an already-correct line is recorded with matching old/new specifiers
     assert changes.repos == {}
     assert changes.lines == {6: ("pydantic", "==2.5.0", "==2.5.0")}
+
+
+@pytest.mark.parametrize(
+    "comment",
+    ["# sync-with-uv-experimental", "# sync-with-uvx", "# sync-with-uv2"],
+)
+def test_sync_additional_dependencies_pragma_lookalike_ignored(comment: str) -> None:
+    """A comment that only looks like the pragma does not trigger syncing."""
+    precommit_text = textwrap.dedent(f"""\
+        repos:
+        - repo: local
+          hooks:
+            - id: mypy
+              additional_dependencies:
+                - pydantic>=2.0  {comment}
+        """)
+    uv_data = {"pydantic": "2.5.0"}
+
+    result, changes = process_config_text(precommit_text, uv_data, config_format="yaml")
+
+    # the line is left untouched and produces no change and no error
+    assert result == precommit_text
+    assert changes.repos == {}
+    assert changes.lines == {}

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -147,12 +147,13 @@ def test_process_precommit_text(
     uv_data = load_uv_lock(sample_uv_lock)
     result, changes = process_config_text(precommit_text, uv_data, config_format="yaml")
     assert result == FIXED_PRECOMMIT_CONTENT
-    assert changes == {
+    assert changes.repos == {
         "black": ("23.9.1", "23.11.0"),
         "ruff": ("v0.0.292", "v0.1.5"),
         "unchanged-package": True,
         "another-package": False,
     }
+    assert changes.lines == {}
 
 
 def test_process_precommit_text_empty() -> None:
@@ -162,7 +163,8 @@ def test_process_precommit_text_empty() -> None:
 
     result, changes = process_config_text(precommit_text, uv_data, config_format="yaml")
     assert result == ""
-    assert changes == {}
+    assert changes.repos == {}
+    assert changes.lines == {}
 
 
 def test_process_precommit_text_no_changes_needed() -> None:
@@ -179,7 +181,8 @@ def test_process_precommit_text_no_changes_needed() -> None:
     result, changes = process_config_text(precommit_text, uv_data, config_format="yaml")
     # Should be identical
     assert result == precommit_text
-    assert changes == {"black": True}
+    assert changes.repos == {"black": True}
+    assert changes.lines == {}
 
 
 def test_process_precommit_text_complex() -> None:
@@ -242,7 +245,7 @@ def test_process_precommit_text_complex() -> None:
     assert "pre-commit-hooks\n  rev: v4.4.0" in result
     assert "/non/url/repo\n  rev: v3" in result
 
-    assert changes == {
+    assert changes.repos == {
         "pre-commit-hooks": False,
         "black": ("23.9.1", "23.11.0"),
         "ruff": ("v0.0.292", "v0.1.5"),
@@ -250,6 +253,8 @@ def test_process_precommit_text_complex() -> None:
         "repo": ("v2", "v3.2.1"),
         "/non/url/repo": False,
     }
+    # the `- types-PyYAML` line has no pragma, so it is not synced
+    assert changes.lines == {}
 
 
 def test_process_precommit_text_with_user_mappings() -> None:
@@ -287,10 +292,11 @@ def test_process_precommit_text_with_user_mappings() -> None:
     assert "custom-tool\n  rev: v2.1.0" in result
     assert "black-pre-commit-mirror\n  rev: 23.11.0" in result
 
-    assert changes == {
+    assert changes.repos == {
         "custom-tool": ("v1.0.0", "v2.1.0"),
         "black": ("23.9.1", "23.11.0"),
     }
+    assert changes.lines == {}
 
 
 @pytest.mark.parametrize(
@@ -357,3 +363,192 @@ def test_process_precommit_text_preserves_line_endings(
 
     # Result should be identical to input when version is already correct
     assert result == precommit_text.replace("23.11.0", "24.0.0")
+
+
+def test_sync_additional_dependencies_pragma() -> None:
+    """Pragma-annotated additional_dependencies are pinned to the uv.lock version."""
+    precommit_text = textwrap.dedent("""\
+        repos:
+        - repo: https://github.com/pre-commit/mirrors-mypy
+          rev: v1.5.1
+          hooks:
+            - id: mypy
+              additional_dependencies:
+                - pydantic==2.0.0  # sync-with-uv
+                - types-PyYAML>=6.0  # sync-with-uv
+                - rich>=10  # not synced, no pragma
+        """)
+    uv_data = {
+        "mypy": "1.5.1",
+        "pydantic": "2.5.0",
+        "types-pyyaml": "6.0.1",
+        "rich": "13.0.0",
+    }
+
+    result, changes = process_config_text(precommit_text, uv_data, config_format="yaml")
+
+    assert "- pydantic==2.5.0  # sync-with-uv" in result
+    # operator is normalized to == and original name casing is preserved
+    assert "- types-PyYAML==6.0.1  # sync-with-uv" in result
+    # lines without a pragma are never touched
+    assert "- rich>=10  # not synced, no pragma" in result
+    # the rev is a per-package repo change; the deps are per-line changes
+    assert changes.repos == {"mypy": True}
+    assert changes.lines == {
+        7: ("pydantic", "==2.0.0", "==2.5.0"),
+        8: ("types-pyyaml", ">=6.0", "==6.0.1"),
+    }
+
+
+def test_sync_additional_dependencies_bare_adds_specifier() -> None:
+    """A pragma dependency without a specifier gets an exact pin added."""
+    precommit_text = textwrap.dedent("""\
+        repos:
+        - repo: local
+          hooks:
+            - id: mypy
+              additional_dependencies:
+                - pydantic  # sync-with-uv
+                - attrs[speedups]  # sync-with-uv
+                - types-PyYAML ; python_version < "3.11"  # sync-with-uv
+        """)
+    uv_data = {"pydantic": "2.5.0", "attrs": "23.2.0", "types-pyyaml": "6.0.1"}
+
+    result, changes = process_config_text(precommit_text, uv_data, config_format="yaml")
+
+    assert "- pydantic==2.5.0  # sync-with-uv" in result
+    # extras are preserved when the pin is inserted
+    assert "- attrs[speedups]==23.2.0  # sync-with-uv" in result
+    # the pin is inserted before an environment marker
+    assert '- types-PyYAML==6.0.1 ; python_version < "3.11"  # sync-with-uv' in result
+    # a bare dependency reports an empty old specifier
+    assert changes.repos == {}
+    assert changes.lines == {
+        6: ("pydantic", "", "==2.5.0"),
+        7: ("attrs", "", "==23.2.0"),
+        8: ("types-pyyaml", "", "==6.0.1"),
+    }
+
+
+def test_sync_additional_dependencies_no_dependency_errors() -> None:
+    """A pragma on a line with no dependency to sync is an error."""
+    precommit_text = textwrap.dedent("""\
+        repos:
+        - repo: local
+          hooks:
+            - id: mypy  # sync-with-uv
+              additional_dependencies:
+                # sync-with-uv
+                - pydantic==2.0.0  # sync-with-uv
+        """)
+    uv_data = {"pydantic": "2.5.0"}
+
+    with pytest.raises(ValueError, match="no dependency to sync") as exc_info:
+        process_config_text(precommit_text, uv_data, config_format="yaml")
+    message = str(exc_info.value)
+    # both the hook id line and the stray comment line are reported
+    assert "line 4: no dependency to sync" in message
+    assert "line 6: no dependency to sync" in message
+
+
+def test_sync_additional_dependencies_multiple_on_line_errors() -> None:
+    """More than one dependency on a pragma line is an error, not a partial sync."""
+    precommit_text = textwrap.dedent("""\
+        repos:
+        - repo: local
+          hooks:
+            - id: mypy
+              additional_dependencies:
+                - pydantic==2.0.0, attrs==1.0  # sync-with-uv
+        """)
+    uv_data = {"pydantic": "2.5.0", "attrs": "23.2.0"}
+
+    with pytest.raises(ValueError, match="more than one dependency") as exc_info:
+        process_config_text(precommit_text, uv_data, config_format="yaml")
+    assert "line 6" in str(exc_info.value)
+
+
+def test_sync_additional_dependencies_extras_and_marker() -> None:
+    """Extras and environment markers are preserved when pinning."""
+    precommit_text = textwrap.dedent("""\
+        repos:
+        - repo: https://github.com/pre-commit/mirrors-mypy
+          rev: v1.5.1
+          hooks:
+            - id: mypy
+              additional_dependencies:
+                - pydantic[email]>=1.0,<3.0  # sync-with-uv
+                - attrs==22.0.0; python_version < "3.11"  # sync-with-uv
+        """)
+    uv_data = {"mypy": "1.5.1", "pydantic": "2.5.0", "attrs": "23.2.0"}
+
+    result, changes = process_config_text(precommit_text, uv_data, config_format="yaml")
+
+    assert "- pydantic[email]==2.5.0  # sync-with-uv" in result
+    assert '- attrs==23.2.0; python_version < "3.11"  # sync-with-uv' in result
+    assert changes.repos == {"mypy": True}
+    assert changes.lines == {
+        7: ("pydantic", ">=1.0,<3.0", "==2.5.0"),
+        8: ("attrs", "==22.0.0", "==23.2.0"),
+    }
+
+
+def test_sync_additional_dependencies_not_in_lock_errors() -> None:
+    """A pragma dependency missing from uv.lock is an error (explicit opt-in)."""
+    precommit_text = textwrap.dedent("""\
+        repos:
+        - repo: local
+          hooks:
+            - id: something
+              additional_dependencies:
+                - some-tool==1.0.0  # sync-with-uv
+        """)
+    uv_data = {"pydantic": "2.5.0"}
+
+    with pytest.raises(ValueError, match=r"'some-tool' is not in uv\.lock") as exc_info:
+        process_config_text(precommit_text, uv_data, config_format="yaml")
+    # the error points at the offending line
+    assert "line 6" in str(exc_info.value)
+
+
+def test_sync_additional_dependencies_reports_all_errors() -> None:
+    """All invalid pragma dependencies are collected before raising."""
+    precommit_text = textwrap.dedent("""\
+        repos:
+        - repo: local
+          hooks:
+            - id: something
+              additional_dependencies:
+                - typo-pkg>=1.0  # sync-with-uv
+                # sync-with-uv
+                - pydantic==2.5.0  # sync-with-uv
+        """)
+    uv_data = {"pydantic": "2.5.0"}
+
+    with pytest.raises(
+        ValueError, match="invalid '# sync-with-uv' dependencies"
+    ) as exc_info:
+        process_config_text(precommit_text, uv_data, config_format="yaml")
+    message = str(exc_info.value)
+    assert "line 6: 'typo-pkg' is not in uv.lock" in message
+    assert "line 7: no dependency to sync" in message
+
+
+def test_sync_additional_dependencies_already_pinned() -> None:
+    """A dependency already at the locked version is reported as unchanged."""
+    precommit_text = textwrap.dedent("""\
+        repos:
+        - repo: local
+          hooks:
+            - id: something
+              additional_dependencies:
+                - pydantic==2.5.0  # sync-with-uv
+        """)
+    uv_data = {"pydantic": "2.5.0"}
+
+    result, changes = process_config_text(precommit_text, uv_data, config_format="yaml")
+
+    assert result == precommit_text
+    # an already-correct line is recorded with matching old/new specifiers
+    assert changes.repos == {}
+    assert changes.lines == {6: ("pydantic", "==2.5.0", "==2.5.0")}

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -451,21 +451,70 @@ def test_sync_additional_dependencies_no_dependency_errors() -> None:
     assert "line 6: no dependency to sync" in message
 
 
-def test_sync_additional_dependencies_multiple_on_line_errors() -> None:
+@pytest.mark.parametrize(
+    "dep_line",
+    [
+        "- pydantic==2.0.0, attrs==1.0  # sync-with-uv",  # comma-separated
+        "- pydantic==2.0.0 attrs==1.0  # sync-with-uv",  # space-separated
+    ],
+    ids=["comma", "space"],
+)
+def test_sync_additional_dependencies_multiple_on_line_errors(dep_line: str) -> None:
     """More than one dependency on a pragma line is an error, not a partial sync."""
-    precommit_text = textwrap.dedent("""\
+    precommit_text = textwrap.dedent(f"""\
         repos:
         - repo: local
           hooks:
             - id: mypy
               additional_dependencies:
-                - pydantic==2.0.0, attrs==1.0  # sync-with-uv
+                {dep_line}
         """)
     uv_data = {"pydantic": "2.5.0", "attrs": "23.2.0"}
 
     with pytest.raises(ValueError, match="more than one dependency") as exc_info:
         process_config_text(precommit_text, uv_data, config_format="yaml")
     assert "line 6" in str(exc_info.value)
+
+
+def test_sync_additional_dependencies_marker_comma_not_confused_for_second_dep() -> (
+    None
+):
+    """A comma inside an environment marker is not mistaken for a second dependency."""
+    precommit_text = textwrap.dedent("""\
+        repos:
+        - repo: local
+          hooks:
+            - id: mypy
+              additional_dependencies:
+                - pydantic>=1.0; extra == "a,b"  # sync-with-uv
+        """)
+    uv_data = {"pydantic": "2.5.0"}
+
+    result, changes = process_config_text(precommit_text, uv_data, config_format="yaml")
+
+    assert '- pydantic==2.5.0; extra == "a,b"  # sync-with-uv' in result
+    assert changes.lines == {6: ("pydantic", ">=1.0", "==2.5.0")}
+
+
+@pytest.mark.parametrize("line_ending", ["\n", "\r\n", "\r"], ids=["LF", "CRLF", "CR"])
+def test_sync_additional_dependencies_preserves_line_endings(line_ending: str) -> None:
+    """Dependency syncing preserves the original line endings (issue #24 area)."""
+    precommit_text = line_ending.join(
+        [
+            "      additional_dependencies:",
+            "        - pydantic>=2.0  # sync-with-uv",
+            "        - attrs  # sync-with-uv",
+        ]
+    )
+    uv_data = {"pydantic": "2.5.0", "attrs": "23.2.0"}
+
+    result, _changes = process_config_text(
+        precommit_text, uv_data, config_format="yaml"
+    )
+
+    assert result == precommit_text.replace("pydantic>=2.0", "pydantic==2.5.0").replace(
+        "- attrs  ", "- attrs==23.2.0  "
+    )
 
 
 def test_sync_additional_dependencies_extras_and_marker() -> None:


### PR DESCRIPTION
Add opt-in syncing of dependency lines (such as `additional_dependencies` entries) to `uv.lock`. A line is processed only when it carries a `# sync-with-uv` pragma comment; its package is then pinned to the exact version from `uv.lock`: an existing specifier (`==`, `>=`, `~=`, ...) is rewritten to an exact `==` pin, and a bare dependency with no specifier has one added.

The pragma-per-line approach is format-agnostic (works in both `.pre-commit-config.yaml` and `prek.toml`) and safe by default, since arbitrary `additional_dependencies` are never touched without an explicit opt-in.

Because the pragma is an explicit request to sync a line, an annotated line that cannot be synced is an error (exit code 123) rather than a silent no-op:

- the package is not present in `uv.lock` (typically a typo or a forgotten add),
- the line has no dependency to sync (the pragma is on a comment or a non-dependency line such as a hook `id`), or
- the line has more than one dependency (only one per pragma line is supported, so the rest are never silently skipped).

All offending lines are reported together with their line numbers, and the config file is left unchanged until they are fixed.

`process_config_text` now returns a `Changes(repos, lines)` result: repo `rev` syncs are reported per package (as before) and dependency pins are reported per line number, so the same package pinned on several lines is reported once per line instead of collapsing to a single entry. The CLI summary gains a "N dependencies changed, M dependencies left unchanged" line when any pragma dependency is present, and both summary lines pluralize by count.

Package names are matched against `uv.lock` after PEP 503 normalization. Extras, environment markers, quoting, and the comment itself are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FB7BB52sP6N6AGpbFTbB4v