### PR TITLE
Pluralize summary counts by number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 - **`prek.toml` support**:
   Sync hook versions in `prek.toml` configs, in addition to `.pre-commit-config.yaml` (#35)
 
+### Bug Fixes
+
+- Pluralize the summary counts by number, so a count of 1 reads "1 package" and other counts read "N packages"
+
 ### Documentation
 
 - Document that custom file locations require updating the `files` setting in `.pre-commit-config.yaml` (#36)

--- a/src/sync_with_uv/cli.py
+++ b/src/sync_with_uv/cli.py
@@ -190,6 +190,11 @@ def _print_diff(
     print("\n".join(diff_lines))
 
 
+def _plural(count: int, singular: str, plural: str) -> str:
+    """Return *singular* when count is exactly 1, otherwise *plural*."""
+    return singular if count == 1 else plural
+
+
 def _print_summary(
     changes: dict[str, bool | tuple[str, str]], *, dry_mode: bool
 ) -> None:
@@ -202,7 +207,9 @@ def _print_summary(
             n_unchanged += 1
     would_be = "would be " if dry_mode else ""
     print(
-        f"{n_changed} package {would_be}changed, "
-        f"{n_unchanged} packages {would_be}left unchanged.",
+        f"{n_changed} {_plural(n_changed, 'package', 'packages')} "
+        f"{would_be}changed, "
+        f"{n_unchanged} {_plural(n_unchanged, 'package', 'packages')} "
+        f"{would_be}left unchanged.",
         file=sys.stderr,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ def test_process_precommit_cli_check(
     assert exc_info.value.code == 1
     captured = capsys.readouterr()
     assert captured.err == (
-        "All done!\n2 package would be changed, 2 packages would be left unchanged.\n"
+        "All done!\n2 packages would be changed, 2 packages would be left unchanged.\n"
     )
     assert captured.out == ""
 
@@ -100,7 +100,7 @@ def test_process_precommit_cli_check_v(
         "another-package: not managed in uv\n"
         "\n"
         "All done!\n"
-        "2 package would be changed, 2 packages would be left unchanged.\n"
+        "2 packages would be changed, 2 packages would be left unchanged.\n"
     )
     assert captured.out == ""
 
@@ -132,7 +132,7 @@ def test_process_precommit_cli_diff(
     assert exc_info.value.code == 0
     captured = capsys.readouterr()
     assert (
-        "All done!\n2 package would be changed, 2 packages would be left unchanged."
+        "All done!\n2 packages would be changed, 2 packages would be left unchanged."
         in captured.err
     )
     assert "-  rev: 23.9.1  # a comment" in captured.out
@@ -166,7 +166,7 @@ def test_process_precommit_cli_with_write(
     assert exc_info.value.code == 0
     captured = capsys.readouterr()
     assert captured.err == (
-        "All done!\n2 package changed, 2 packages left unchanged.\n"
+        "All done!\n2 packages changed, 2 packages left unchanged.\n"
     )
     assert captured.out == ""
 
@@ -240,7 +240,8 @@ def test_process_precommit_cli_check_no_changes_needed(
     captured = capsys.readouterr()
     assert "All done!" in captured.err
     assert (
-        "0 package would be changed, 2 packages would be left unchanged" in captured.err
+        "0 packages would be changed, 2 packages would be left unchanged"
+        in captured.err
     )
     assert captured.out == ""
 

--- a/tests/test_prek_cli.py
+++ b/tests/test_prek_cli.py
@@ -46,7 +46,7 @@ def test_cli_prek_toml_write(
         app(["-p", str(sample_prek_config), "-u", str(sample_uv_lock)])
     assert exc_info.value.code == 0
     captured = capsys.readouterr()
-    assert "3 package changed" in captured.err
+    assert "3 packages changed" in captured.err
 
     content = sample_prek_config.read_text()
     assert 'rev = "v0.15.0"' in content  # ruff updated


### PR DESCRIPTION
Extracts just the pluralization fix from #56, independent of that PR's dependency-sync feature.

The end-of-run summary hardcoded "package" for the changed count and "packages" for the unchanged count, so it read "1 packages" or "2 package" depending on the numbers. This adds a small `_plural` helper and uses it for both counts: a count of 1 reads "package", any other count reads "packages".

Tests updated to expect the pluralized output; verified the singular case (`1 package`) manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)